### PR TITLE
Column resize logic. Thanks to Lc0rE: reused part of code in pr#18

### DIFF
--- a/src/ColumnHeader.js
+++ b/src/ColumnHeader.js
@@ -1,51 +1,84 @@
-import React from "react";
-import "../styles/column-header-style.css";
+import React from 'react';
+import '../styles/column-header-style.css';
 
 class ColumnHeader extends React.Component {
   state = {
     filterActive: false,
     sortActive: false,
     sorting: null,
-    hover: false
+    hover: false,
+    resized: false,
+    startX: null,
+    startColumnWidth: null,
+    columnWidth: this.props.columnWidth,
   };
 
   toggleHover = () => {
     this.setState(prevState => {
       return {
-        hover: !prevState.hover
+        hover: !prevState.hover,
       };
     });
   };
 
-
-  onColumnWidth( columnWidth ) {
-
-    columnWidth = this.props.onColumnWidth ?
-      this.props.onColumnWidth( columnWidth, this.props.index, this )
+  onColumnWidth(columnWidth) {
+    columnWidth = this.props.onColumnWidth
+      ? this.props.onColumnWidth(columnWidth, this.props.index, this)
       : columnWidth;
 
-    columnWidth =  columnWidth || this.props.defaultColumnWidth || 150;
+    columnWidth = columnWidth || this.props.defaultColumnWidth || 150;
 
     return columnWidth;
   }
 
+  resizeColumns = event => {
+    let diffWidth = event.pageX - this.state.startX;
+
+    this.setState({
+      resized: true,
+      columnWidth: this.state.startColumnWidth + diffWidth,
+    });
+  };
+
+  handleColumnsResize = event => {
+    this.setState(
+      {
+        startX: event.pageX,
+        startColumnWidth: this.state.columnWidth,
+      },
+      () => {
+        document.addEventListener('mousemove', this.resizeColumns);
+        document.addEventListener('mouseup', this.removeListeners);
+      }
+    );
+  };
+
+  removeListeners = () => {
+    this.onColumnWidth(this.state.columnWidth);
+    document.removeEventListener('mousemove', this.resizeColumns);
+    document.removeEventListener('mouseup', this.handleColumnsResize);
+  };
+
   render() {
     let content;
-    if( this.props.headColRender )
+    if (this.props.headColRender)
       content = this.props.headColRender(this.props.column);
-    else
-      content = this.props.column;
+    else content = this.props.column;
 
     let style = {};
 
-    style.width = this.props.columnWidth; // this.onColumnWidth();
-    style.minWidth = this.props.columnWidth;
-    style.maxWidth = this.props.columnWidth;
+    style.width = style.minWidth = style.maxWidth = this.state.resized
+      ? this.state.columnWidth
+      : this.props.columnWidth;
+
+    // style.width = this.props.columnWidth; // this.onColumnWidth();
+    // style.minWidth = this.props.columnWidth;
+    // style.maxWidth = this.props.columnWidth;
     // console.log(style);
 
     return (
       <div
-        className="ft-table--cell__header"
+        className='ft-table--cell__header'
         style={style}
         onClick={() => {
           this.props.onColumnHeaderClick(this.props.index);
@@ -54,6 +87,10 @@ class ColumnHeader extends React.Component {
         onMouseLeave={this.toggleHover}
       >
         {content}
+        <div
+          className='ft-table--cell__header--resizable'
+          onMouseDown={this.handleColumnsResize}
+        />
       </div>
     );
   }

--- a/src/ForteTable.js
+++ b/src/ForteTable.js
@@ -44,7 +44,7 @@ class ForteTable extends React.Component {
    * @param headerComponent - the headerColumn component that has been sized.
    * @return {*} the new value of the column width, eventually modified by a custom callback.
    */
-  onColumnWidth(columnWidth, index, headerComponent) {
+  onColumnWidth = (columnWidth, index, headerComponent) => {
     let column = this.props.columns()[index];
 
     if (this.props.onColumnWidth)
@@ -55,12 +55,12 @@ class ForteTable extends React.Component {
       );
 
     // updates the state... and redraws the table
-    let columnsWidth = this.getState(columnsWidth); // gets the array of the columns width
-    columnsWidth[index] = columnsWidth; // updates the value in the corresponding position
+    let columnsWidth = this.state.columnsWidth; // gets the array of the columns width
+    columnsWidth[index] = columnWidth; // updates the value in the corresponding position
     this.setState({ columnsWidth: columnsWidth }); // saves the array of columns width into state (and refresh the whole table)
 
     return columnWidth;
-  }
+  };
 
   /** Checks if new row is to be rendered
    *

--- a/src/TableRow.js
+++ b/src/TableRow.js
@@ -15,7 +15,7 @@ import styles from '../styles/table-row-styles';
  *
  */
 
-class TableRow extends React.Component {
+class TableRow extends React.PureComponent {
   state = {
     isValid: true, // / true if the record has valid data, false if there is some error. False prevent record to be saved
     _loading: false,
@@ -43,16 +43,16 @@ class TableRow extends React.Component {
    * @param nextProps - properties to be set
    * @returns {boolean} true if the row is been selected and wan not, or viceversa.
    */
-  shouldComponentUpdate(nextProps, nextState) {
-    return (
-      this.props.isActive ||
-      nextProps.isActive ||
-      this.props.isSelected ||
-      nextProps.isSelected ||
-      nextState.hover !== this.state.hover ||
-      nextProps.index !== this.props.index
-    );
-  }
+  // shouldComponentUpdate(nextProps, nextState) {
+  //   return (
+  //     this.props.isActive ||
+  //     nextProps.isActive ||
+  //     this.props.isSelected ||
+  //     nextProps.isSelected ||
+  //     nextState.hover !== this.state.hover ||
+  //     nextProps.index !== this.props.index
+  //   );
+  // }
 
   handleRowHover = () => {
     this.setState(prevState => ({
@@ -77,7 +77,9 @@ class TableRow extends React.Component {
           borderLeft:
             this.props.isActive && !this.props.newRow
               ? '3px solid #108ee9'
-              : this.props.newRow ? '3px solid #00a854' : '',
+              : this.props.newRow
+              ? '3px solid #00a854'
+              : '',
         }}
       >
         {this.state.id === -1 && !this.state.valid ? (

--- a/styles/column-header-style.css
+++ b/styles/column-header-style.css
@@ -10,10 +10,11 @@
   /*background-color: #f5f5f5;*/
   font-weight: bold;
   vertical-align: middle;
-  min-width: 150px;
-  max-width: 150px;
+  /* min-width: 150px;
+  max-width: 150px; */
   box-sizing: border-box;
   font-size: 11px;
+  position: relative;
 }
 
 .ft-table--cell__header:hover {
@@ -27,4 +28,24 @@
   justify-content: space-between;
   background-color: #fff;
   height: 100%;
+}
+
+/*
+ * added for resizing
+ */
+.ft-table--cell__header--resizable {
+  height: 100%;
+  width: 5px;
+  float: right;
+  position: absolute;
+  right: 0;
+  top: 0;
+  cursor: col-resize;
+}
+
+.ft-table--cell__header--resizable:active {
+  background: #108ee9;
+}
+.ft-table--cell__header--resizable:hover {
+  background: #108ee9;
 }


### PR DESCRIPTION
Got code form #18 'Add first logic to resize columns'.
TableRow now is PureComponent which should update only when props change.
Fix onColumnWidth which sets array of sizes after drag event initiated in ColumnHeader